### PR TITLE
Drop `exit $(...)` stuff from file tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,10 +35,10 @@ test:
     - python 3.4.*  # [win and py34]
     - python 3.5.*  # [win and py35]
   commands:
-    - exit $(test -f ${PREFIX}/lib/libgflags.dylib)            # [osx]
-    - exit $(test -f ${PREFIX}/lib/libgflags_nothreads.dylib)  # [osx]
-    - exit $(test -f ${PREFIX}/lib/libgflags.so)               # [linux]
-    - exit $(test -f ${PREFIX}/lib/libgflags_nothreads.so)     # [linux]
+    - test -f ${PREFIX}/lib/libgflags.dylib                    # [osx]
+    - test -f ${PREFIX}/lib/libgflags_nothreads.dylib          # [osx]
+    - test -f ${PREFIX}/lib/libgflags.so                       # [linux]
+    - test -f ${PREFIX}/lib/libgflags_nothreads.so             # [linux]
     - if not exist %PREFIX%\\Library\\bin\\gflags.dll exit 1   # [win]
     - if not exist %PREFIX%\\Library\\lib\\gflags.lib exit 1   # [win]
 


### PR DESCRIPTION
These basically are a holdover from a long time ago. It appears they no longer work properly. So this simply drops them. `test -f` appears to actually do the right thing in all cases it has been used. So it should be more than sufficient for performing the actual tests.